### PR TITLE
Switches to more stable Eleventy version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@11ty/eleventy": "^2.0.0-canary.11",
+    "@11ty/eleventy": "2.0.0-beta.2",
     "@11ty/eleventy-fetch": "^3.0.0",
     "airtable": "^0.11.2",
     "marked": "^4.0.12",


### PR DESCRIPTION
Also only specifies one version to avoid getting unexpected upgrades.