### PR TITLE
Groups units by type and open status.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -185,12 +185,12 @@ module.exports = function(eleventyConfig) {
 
   // Sorts items according to the ranking defined in SORT_RANKING.
   eleventyConfig.addFilter("rankSort", function(values, properties="") {
-    let sorted = values.sort(function (a, b) {
-      properties = [].concat(properties);
+    let sorted = values.sort(function(a, b) {
+      const props = [].concat(properties);
       let ret = 0;
-      for (const property of properties) {
-        let valA = property ? a[property] : a;
-        let valB = property ? b[property] : b;
+      for (const prop of props) {
+        let valA = prop ? a[prop] : a;
+        let valB = prop ? b[prop] : b;
         let rankA = SORT_RANKING.get(valA);
         let rankB = SORT_RANKING.get(valB);
         // Special handling for the -1 rank, which is always sorted last.

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -84,16 +84,22 @@ module.exports = function(eleventyConfig) {
     return filtered;
   });
 
-  eleventyConfig.addFilter("groupBy", function(collection, key) {
+  eleventyConfig.addFilter("groupBy", function(collection, keys) {
+    const SEPARATOR = "__"
     const groupMap = {};
+    const keyArr = [].concat(keys);
     for (const item of collection) {
-      const keyValue = item[key];
+      const keyValue = keyArr.map(k => item[k]).join(SEPARATOR);
       groupMap[keyValue] = groupMap[keyValue] || [];
       groupMap[keyValue].push(item);
     }
     const grouped = []
     for (const groupKey in groupMap) {
-      grouped.push({"key": groupKey, "values": groupMap[groupKey]});
+      const entry = {"key": groupKey, "values": groupMap[groupKey]};
+      for (const [index, key] of groupKey.split(SEPARATOR).entries()) {
+        entry["key" + index] = key;
+      }
+      grouped.push(entry);
     }
     return grouped;
   });
@@ -178,32 +184,43 @@ module.exports = function(eleventyConfig) {
   });
 
   // Sorts items according to the ranking defined in SORT_RANKING.
-  eleventyConfig.addFilter("rankSort", function(values, property="") {
-    let sorted = values.sort(function(a, b) {
-      let valA = property ? a[property] : a;
-      let valB = property ? b[property] : b;
-      let rankA = SORT_RANKING.get(valA);
-      let rankB = SORT_RANKING.get(valB);
-      // Special handling for the -1 rank, which is always sorted last.
-      if (rankB < 0) {
-        return -1;
-      } else if (rankA < 0) {
-        return 1;
-      // Sort by rank if both items have one.
-      } else if (rankA && rankB) {
-        return rankA - rankB;
-      // Put unranked items after the ranked ones.
-      } else if (rankA && !rankB) {
-        return -1;
-      } else if (!rankA && rankB) {
-        return 1;
-      // Sort unranked items alphabetically.
-      } else if (valA < valB) {
-        return -1;
-      } else if (valA > valB) {
-        return 1;
+  eleventyConfig.addFilter("rankSort", function(values, properties="") {
+    let sorted = values.sort(function (a, b) {
+      properties = [].concat(properties);
+      let ret = 0;
+      for (const property of properties) {
+        let valA = property ? a[property] : a;
+        let valB = property ? b[property] : b;
+        let rankA = SORT_RANKING.get(valA);
+        let rankB = SORT_RANKING.get(valB);
+        // Special handling for the -1 rank, which is always sorted last.
+        if (rankB < 0) {
+          ret = -1;
+        } else if (rankA < 0) {
+          ret = 1;
+        // Sort by rank if both items have one.
+        } else if (rankA && rankB) {
+          ret = rankA - rankB;
+        // Put unranked items after the ranked ones.
+        } else if (rankA && !rankB) {
+          ret = -1;
+        } else if (!rankA && rankB) {
+          ret = 1;
+        // Sort unranked items alphabetically.
+        } else if (valA < valB) {
+          ret = -1;
+        } else if (valA > valB) {
+          ret = 1;
+        }
+        // If the values are the same, continue on with the next property to
+        // try to sort them.
+        // Otherwise, get out of the loop because the items can be sorted via
+        // this property.
+        if (ret != 0) {
+          break;
+        }
       }
-      return 0;
+      return ret;
     });
     return sorted;
   });

--- a/src/site/static/apartment-details.liquid
+++ b/src/site/static/apartment-details.liquid
@@ -71,7 +71,9 @@ eleventyComputed:
 
 <div class="rent_tables">
   {% assign defaultNoDataStr = "Call for info" %}
-  {% assign unitsByType = apartment.units | groupBy: "type" | rankSort: "key" %}
+  {% assign groupByKeys = "type,openStatus" | split: "," %}
+  {% assign sortKeys = "key0,key1" | split: "," %}
+  {% assign unitsByType = apartment.units | groupBy: groupByKeys | rankSort: sortKeys %}
   {% comment %}
   Only show the income bracket column in the rent table if there is more than
   one rent offering for that unit type OR there is at least one filled-in
@@ -89,14 +91,15 @@ eleventyComputed:
     {% endif %}
   {% endfor %}
   {% for unitGroup in unitsByType %}
-    {% assign unitType = unitGroup.key %}
     {% assign units = unitGroup.values | sortUnitOfferings %}
     {% comment %}
     'units' is guaranteed to have at least one item since it is generated
-    via grouping. Occupancy limits and status should always be the same in every
-    entry for a given rental property & unit type, so just take the first one
-    here.
+    via grouping. Occupancy limits should always be the same in every entry for
+    a given rental property & unit type, so just take the first one here.
+    Type, and status are guaranteed to be uniform across all units in this
+    group because type and status are the grouping keys.
     {% endcomment %}
+    {% assign unitType = units[0].type %}
     {% assign occupancyLimit = units[0].occupancyLimit %}
     {% assign openStatus = units[0].openStatus %}
     {%- capture badgeMod -%}


### PR DESCRIPTION
If an apartment has multiple unit offerings with the same type but different statuses, those are now displayed separately on the apartment details page.  Previously, all offerings with the same type would be grouped together and the status of the first offering would be incorrectly displayed for the whole group.