### PR TITLE
Adds VA Pension tests, fixes bugs with same.

### DIFF
--- a/src/site/_includes/js/eligibility.js
+++ b/src/site/_includes/js/eligibility.js
@@ -2023,9 +2023,7 @@ function vaPensionResult(input) {
   const meetsAgeReq = ge(input.age, cnst.vaPension.MIN_ELDERLY_AGE);
   const isProgramQualified = or(
     input.existingSsiMe,
-    input.existingSsiHousehold,
     input.existingSsdiMe,
-    input.existingSsdiHousehold,
     ssiResult(input).eligible,
     ssdiResult(input).eligible);
 

--- a/src/site/_includes/js/eligibility.js
+++ b/src/site/_includes/js/eligibility.js
@@ -2052,12 +2052,13 @@ function vaPensionResult(input) {
           gt(duty.start, new Date(dateStrToLocal(cnst.vaPension.LATE_DUTY_AFTER))),
           or(
             ge(duration, cnst.vaPension.MIN_LATE_DUTY_DURATION),
-            isOneOf('mil-svc-duration', 'full-dur-yes')),
+            input.servedFullDuration),
           isDuringWartime),
         and(
           eq(duty.type, 'active-duty'),
           input.officer,
           gt(duty.start, new Date(dateStrToLocal(cnst.vaPension.OFFICER_DUTY_AFTER))),
+          ge(duration, cnst.vaPension.MIN_LATE_DUTY_DURATION),
           not(hasRecentPriorActiveDuty))));
   }
 
@@ -2233,6 +2234,7 @@ function buildInputObj() {
     dischargeStatus: getValueOrNull('your-discharge-status'),
     enlisted: getValueOrNull('enlisted'),
     officer: getValueOrNull('officer'),
+    servedFullDuration: getValueOrNull('full-dur-yes'),
     dutyPeriods: [],
     income: {},
     assets: getIncomeValues(document.getElementById('page-income-assets')),

--- a/src/site/_includes/js/eligibility.js
+++ b/src/site/_includes/js/eligibility.js
@@ -461,9 +461,9 @@ function dateOrToday(inputStr) {
 // This function will return null if the 'start' or 'end' is null.
 function withinInterval(start, end, intervals) {
   return or(
-    ...intervals.map(w => or(
-      and(ge(start, w.start), lt(start, w.end)),
-      and(gt(end, w.start), le(end, w.end)))
+    ...intervals.map(i => and(
+      lt(start, i.end),
+      gt(end, i.start))
     ));
 }
 
@@ -2025,7 +2025,7 @@ function vaPensionResult(input) {
   const meetsServiceReq = [];
   for (const duty of input.dutyPeriods) {
     const duration = getNumberOfDays(duty.start, duty.end);
-    const isDuringWartime = withinWartime(duty.start, duty.end);
+    const isDuringWartime = withinInterval(duty.start, duty.end, wartimes);
     const otherDutyPeriods = input.dutyPeriods.filter(p => p !== duty);
     // TODO: does "active duty" include active duty for training and
     // inactive duty for training? https://www.va.gov/pension/eligibility/

--- a/src/site/_includes/js/eligibility.js
+++ b/src/site/_includes/js/eligibility.js
@@ -462,8 +462,8 @@ function dateOrToday(inputStr) {
 function withinInterval(start, end, intervals) {
   return or(
     ...intervals.map(i => and(
-      lt(start, i.end),
-      gt(end, i.start))
+      le(start, i.end),
+      ge(end, i.start))
     ));
 }
 
@@ -2008,10 +2008,11 @@ function vaPensionResult(input) {
   const wartimes = cnst.vaPension.WARTIMES.map(
     p => ({start: dateOrToday(p[0]), end: dateOrToday(p[1])}));
 
-  const meetsDischargeReq = and(
-    ne(input.dischargeStatus, 'dishonorable'),
-    ne(input.dischargeStatus, 'oth'),
-    ne(input.dischargeStatus, 'bad-conduct'));
+  const meetsDischargeReq = not(isOneOf(input.dischargeStatus, [
+    'dishonorable',
+    'oth',
+    'bad-conduct',
+  ]));
 
   const meetsAgeReq = ge(input.age, cnst.vaPension.MIN_ELDERLY_AGE);
   const isProgramQualified = or(
@@ -2026,6 +2027,7 @@ function vaPensionResult(input) {
   for (const duty of input.dutyPeriods) {
     const duration = getNumberOfDays(duty.start, duty.end);
     const isDuringWartime = withinInterval(duty.start, duty.end, wartimes);
+    // TODO: test thie prior active duty logic.
     const otherDutyPeriods = input.dutyPeriods.filter(p => p !== duty);
     // TODO: does "active duty" include active duty for training and
     // inactive duty for training? https://www.va.gov/pension/eligibility/
@@ -2436,6 +2438,7 @@ if (typeof module !== 'undefined' && module.exports) {
     ssdiResult,
     upliftResult,
     vaDisabilityResult,
+    vaPensionResult,
     vtaParatransitResult,
     wicResult,
   };

--- a/src/site/_includes/js/eligibility.js
+++ b/src/site/_includes/js/eligibility.js
@@ -451,6 +451,22 @@ function dateOrToday(inputStr) {
   return today;
 }
 
+// Returns true if the time period defined by 'start' and 'end' overlaps at
+// least one interval in the list of 'intervals'.
+//
+// The 'intervals' parameter should be a list of objects with 'start' and 'end'
+// properties. All 'start' and 'end' (input parameters and object properties)
+// should be Dates.
+//
+// This function will return null if the 'start' or 'end' is null.
+function withinInterval(start, end, intervals) {
+  return or(
+    ...intervals.map(w => or(
+      and(ge(start, w.start), lt(start, w.end)),
+      and(gt(end, w.start), le(end, w.end)))
+    ));
+}
+
 // Shows or hides the element 'elem' via a class name.
 function setElementVisibility(elem, makeVisible) {
   if (elem) {
@@ -1989,15 +2005,6 @@ function ssdiResult(input) {
 }
 
 function vaPensionResult(input) {
-
-  function withinWartime(start, end) {
-    return or(
-      ...wartimes.map(w => or(
-        and(ge(start, w.start), lt(start, w.end)),
-        and(gt(end, w.start), le(end, w.end)))
-      ));
-  }
-
   const wartimes = cnst.vaPension.WARTIMES.map(
     p => ({start: dateOrToday(p[0]), end: dateOrToday(p[1])}));
 
@@ -2403,6 +2410,7 @@ if (typeof module !== 'undefined' && module.exports) {
     getNumberOfDays,
     formatUsDate,
     dateOrToday,
+    withinInterval,
     indexOfAll,
     isOneOf,
     categoryTotal,

--- a/src/site/_includes/js/eligibility.js
+++ b/src/site/_includes/js/eligibility.js
@@ -2033,7 +2033,7 @@ function vaPensionResult(input) {
   for (const duty of input.dutyPeriods) {
     const duration = getNumberOfDays(duty.start, duty.end);
     const isDuringWartime = withinInterval(duty.start, duty.end, wartimes);
-    // TODO: test thie prior active duty logic.
+    // TODO: test this prior active duty logic.
     const otherDutyPeriods = input.dutyPeriods.filter(p => p !== duty);
     // TODO: does "active duty" include active duty for training and
     // inactive duty for training? https://www.va.gov/pension/eligibility/

--- a/src/site/_includes/js/eligibility.js
+++ b/src/site/_includes/js/eligibility.js
@@ -437,6 +437,20 @@ function formatUsDate(date) {
   return `${date1.getMonth() + 1}/${date1.getDate()}/${date1.getFullYear()}`;
 }
 
+// Converts a date string to a Date or returns a Date corresponding to today if
+// the input string is empty.
+function dateOrToday(inputStr) {
+  if (inputStr) {
+    return new Date(dateStrToLocal(inputStr));
+  }
+  let today = new Date();
+  today.setHours(0);
+  today.setMinutes(0);
+  today.setSeconds(0);
+  today.setMilliseconds(0);
+  return today;
+}
+
 // Shows or hides the element 'elem' via a class name.
 function setElementVisibility(elem, makeVisible) {
   if (elem) {
@@ -1975,17 +1989,6 @@ function ssdiResult(input) {
 }
 
 function vaPensionResult(input) {
-  function dateOrToday(inputStr) {
-    if (inputStr) {
-      return new Date(dateStrToLocal(inputStr));
-    }
-    let today = new Date();
-    today.setHours(0);
-    today.setMinutes(0);
-    today.setSeconds(0);
-    today.setMilliseconds(0);
-    return today;
-  }
 
   function withinWartime(start, end) {
     return or(
@@ -2399,6 +2402,7 @@ if (typeof module !== 'undefined' && module.exports) {
     dateStrToLocal,
     getNumberOfDays,
     formatUsDate,
+    dateOrToday,
     indexOfAll,
     isOneOf,
     categoryTotal,

--- a/src/site/_includes/js/test/eligibility-utils.test.js
+++ b/src/site/_includes/js/test/eligibility-utils.test.js
@@ -164,6 +164,18 @@ describe('withinInterval', () => {
     expect(elig.withinInterval(start, end, intervals)).toBe(true);
   });
 
+  test('Returns true for a period overlapping the start date of an interval', () => {
+    const start = new Date('1969-01-01');
+    const end = new Date(intervals[0].start);
+    expect(elig.withinInterval(start, end, intervals)).toBe(true);
+  });
+
+  test('Returns true for a period overlapping the end date of an interval', () => {
+    const start = new Date(intervals[0].end);
+    const end = new Date('1970-12-31');
+    expect(elig.withinInterval(start, end, intervals)).toBe(true);
+  });
+
   test('Returns false for a period not overlapping any intervals', () => {
     let start = new Date('2023-01-01');
     let end = new Date('2023-07-01');

--- a/src/site/_includes/js/test/eligibility-utils.test.js
+++ b/src/site/_includes/js/test/eligibility-utils.test.js
@@ -100,6 +100,22 @@ describe('getNumberOfDays', () => {
   });
 });
 
+describe('dateOrToday', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("Returns today's date for empty input", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2000-01-01T00:00'));
+    expect(elig.dateOrToday('').getTime()).toBe(946713600000);
+  });
+
+  test('Converts a date string to a Date', () => {
+    expect(elig.dateOrToday('1975-08-20').getTime()).toBe(177750000000);
+  });
+});
+
 describe('Null-passing OR', () => {
   test('Combines boolean inputs', () => {
     expect(elig.or(true, true)).toBe(true);

--- a/src/site/_includes/js/test/eligibility-utils.test.js
+++ b/src/site/_includes/js/test/eligibility-utils.test.js
@@ -116,6 +116,28 @@ describe('dateOrToday', () => {
   });
 });
 
+describe('withinInterval', () => {
+  let intervals;
+  beforeEach(() => {
+    intervals = [
+      {start: new Date('1970-01-01'), end: new Date('1970-12-01')},
+      {start: new Date('2001-01-01'), end: new Date('2020-01-01')},
+    ];
+  });
+
+  test('Returns null for null start or end parameter', () => {
+    const testDate = new Date('1999-12-31');
+    expect(elig.withinInterval(testDate, null, intervals)).toBe(null);
+    expect(elig.withinInterval(null, testDate, intervals)).toBe(null);
+  });
+
+  test('Returns true for a period overlapping a given interval', () => {
+    let start = new Date('1969-01-01');
+    let end = new Date('1970-02-01');
+    expect(elig.withinInterval(start, end, intervals)).toBe(true);
+  });
+});
+
 describe('Null-passing OR', () => {
   test('Combines boolean inputs', () => {
     expect(elig.or(true, true)).toBe(true);

--- a/src/site/_includes/js/test/eligibility-utils.test.js
+++ b/src/site/_includes/js/test/eligibility-utils.test.js
@@ -106,13 +106,16 @@ describe('dateOrToday', () => {
   });
 
   test("Returns today's date for empty input", () => {
+    const now = new Date('2000-01-01T00:00');
     jest.useFakeTimers();
-    jest.setSystemTime(new Date('2000-01-01T00:00'));
-    expect(elig.dateOrToday('').getTime()).toBe(946713600000);
+    jest.setSystemTime(now);
+    expect(elig.dateOrToday('').getTime()).toBe(now.getTime());
   });
 
   test('Converts a date string to a Date', () => {
-    expect(elig.dateOrToday('1975-08-20').getTime()).toBe(177750000000);
+    const expectedDate = new Date('1975-08-20T00:00');
+    expect(
+      elig.dateOrToday('1975-08-20').getTime()).toBe(expectedDate.getTime());
   });
 });
 

--- a/src/site/_includes/js/test/eligibility-utils.test.js
+++ b/src/site/_includes/js/test/eligibility-utils.test.js
@@ -131,10 +131,46 @@ describe('withinInterval', () => {
     expect(elig.withinInterval(null, testDate, intervals)).toBe(null);
   });
 
-  test('Returns true for a period overlapping a given interval', () => {
-    let start = new Date('1969-01-01');
-    let end = new Date('1970-02-01');
+  test('Returns true for a period ending within one interval', () => {
+    const start = new Date('1969-01-01');
+    const end = new Date('1970-02-01');
     expect(elig.withinInterval(start, end, intervals)).toBe(true);
+  });
+
+  test('Returns true for a period starting within one interval', () => {
+    const start = new Date('2002-01-01');
+    const end = new Date('2023-01-01');
+    expect(elig.withinInterval(start, end, intervals)).toBe(true);
+  });
+
+  test('Returns true for a period fully overlapping one interval', () => {
+    const start = new Date('1969-01-01');
+    const end = new Date('1970-12-31');
+    expect(elig.withinInterval(start, end, intervals)).toBe(true);
+  });
+
+  test('Returns true for a period fully overlapping multiple intervals', () => {
+    const start = new Date('1969-01-01');
+    const end = new Date('2023-01-01');
+    expect(elig.withinInterval(start, end, intervals)).toBe(true);
+  });
+
+  test('Returns true for a period fully within one intervals', () => {
+    const start = new Date('1970-03-01');
+    const end = new Date('1970-04-01');
+    expect(elig.withinInterval(start, end, intervals)).toBe(true);
+  });
+
+  test('Returns false for a period not overlapping any intervals', () => {
+    let start = new Date('2023-01-01');
+    let end = new Date('2023-07-01');
+    expect(elig.withinInterval(start, end, intervals)).toBe(false);
+    start = new Date('1989-01-01');
+    end = new Date('1989-03-01');
+    expect(elig.withinInterval(start, end, intervals)).toBe(false);
+    start = new Date('1969-01-01');
+    end = new Date('1969-03-01');
+    expect(elig.withinInterval(start, end, intervals)).toBe(false);
   });
 });
 


### PR DESCRIPTION
A date is now correctly considered within wartime if it is exactly the start or end date of a wartime period.

Service duration is now correctly used for officers serving after Oct 16, 1981.

The "full duration" question response is now correctly used in the service duration logic.

Removes check for SSI or SSDI from another household member, as only the applicant matters.