### PR TITLE
Changes the "call for status" badge on the housing page to "call for availability"

### DIFF
--- a/netlify/functions/next-property.js
+++ b/netlify/functions/next-property.js
@@ -17,7 +17,7 @@ const SORT_RANKING = new Map([
   ['Available', 1],
   ['Waitlist Open', 2],
   ['Waitlist Closed', 3],
-  ['Call for Status', 4],
+  ['Call for Availability', 4],
 ]);
 
 // Sorts rent offerings so that the generally cheaper offerings are first.

--- a/src/config/eleventy-base-config.js
+++ b/src/config/eleventy-base-config.js
@@ -14,7 +14,7 @@ const SORT_RANKING = new Map([
   ['Available', 1],
   ['Waitlist Open', 2],
   ['Waitlist Closed', 3],
-  ['Call for Status', 4],
+  ['Call for Availability', 4],
   // Populations Served
   ['General Population', 1],
   ['Seniors', 2],

--- a/src/site/_data/housing.js
+++ b/src/site/_data/housing.js
@@ -120,7 +120,7 @@ const fetchUnitRecords = async () => {
         units.push({
           parent_id: record.get('_DISPLAY_ID')?.[0],
           type: record.get('TYPE'),
-          openStatus: record.get('STATUS'),
+          openStatus: record.get('STATUS') === 'Call for Status' ? 'Call for Availability' : record.get('STATUS'),
           occupancyLimit: {
             min: record.get('MIN_OCCUPANCY'),
             max: record.get('MAX_OCCUPANCY'),

--- a/src/site/serverless/affordable-housing.liquid
+++ b/src/site/serverless/affordable-housing.liquid
@@ -256,7 +256,7 @@ Narrow your search with the filter options below or <a href="#results">scroll</a
             {%- for status in allStatuses -%}
               <p>
                 {%- capture badgeMod -%}
-                  {%- if status == "Call for Status" -%}
+                  {%- if status == "Call for Availability" -%}
                     badge__warn
                   {%- elsif status == "Waitlist Closed" -%}
                     badge__bad

--- a/src/site/serverless/affordable-housing.liquid
+++ b/src/site/serverless/affordable-housing.liquid
@@ -256,7 +256,7 @@ Narrow your search with the filter options below or <a href="#results">scroll</a
             {%- for status in allStatuses -%}
               <p>
                 {%- capture badgeMod -%}
-                  {%- if status == "Call for Availability" or status == "Call for Status" -%}
+                  {%- if status == "Call for Availability" -%}
                     badge__warn
                   {%- elsif status == "Waitlist Closed" -%}
                     badge__bad

--- a/src/site/serverless/affordable-housing.liquid
+++ b/src/site/serverless/affordable-housing.liquid
@@ -256,7 +256,7 @@ Narrow your search with the filter options below or <a href="#results">scroll</a
             {%- for status in allStatuses -%}
               <p>
                 {%- capture badgeMod -%}
-                  {%- if status == "Call for Availability" -%}
+                  {%- if status == "Call for Availability" or status == "Call for Status" -%}
                     badge__warn
                   {%- elsif status == "Waitlist Closed" -%}
                     badge__bad

--- a/src/site/static/apartment-details.liquid
+++ b/src/site/static/apartment-details.liquid
@@ -104,7 +104,7 @@ eleventyComputed:
     {% assign occupancyLimit = units[0].occupancyLimit %}
     {% assign openStatus = units[0].openStatus %}
     {%- capture badgeMod -%}
-      {%- if openStatus == "Call for Availability" -%}
+      {%- if openStatus == "Call for Availability" or openStatus == "Call for Status" -%}
         badge__warn
       {%- elsif openStatus == "Waitlist Closed" -%}
         badge__bad

--- a/src/site/static/apartment-details.liquid
+++ b/src/site/static/apartment-details.liquid
@@ -104,7 +104,7 @@ eleventyComputed:
     {% assign occupancyLimit = units[0].occupancyLimit %}
     {% assign openStatus = units[0].openStatus %}
     {%- capture badgeMod -%}
-      {%- if openStatus == "Call for Status" -%}
+      {%- if openStatus == "Call for Availability" -%}
         badge__warn
       {%- elsif openStatus == "Waitlist Closed" -%}
         badge__bad

--- a/src/site/static/apartment-details.liquid
+++ b/src/site/static/apartment-details.liquid
@@ -104,7 +104,7 @@ eleventyComputed:
     {% assign occupancyLimit = units[0].occupancyLimit %}
     {% assign openStatus = units[0].openStatus %}
     {%- capture badgeMod -%}
-      {%- if openStatus == "Call for Availability" or openStatus == "Call for Status" -%}
+      {%- if openStatus == "Call for Availability" -%}
         badge__warn
       {%- elsif openStatus == "Waitlist Closed" -%}
         badge__bad


### PR DESCRIPTION
Before:
![343953796-dd1763c0-ead8-4f3a-b375-7f0ffa2ff492](https://github.com/theunitedeffort/theunitedeffort.org/assets/66636627/8add11ad-a626-4d53-94b5-7787e0ddf51b)
After:
![image](https://github.com/theunitedeffort/theunitedeffort.org/assets/66636627/8b9b9dec-ab35-45e5-96a1-c32de4bcea0a)

The current solution changes the status badge of a housing property to "Call for Availability" if the returned value from Airtable is "Call for Status", and leaves the status return value alone otherwise. In the future, the respective field on Airtable should be changed to "Call for Availability" as well, and the code (presently `housing.js` at line 123) should be changed again to remove the backward compatibility functionality. See #57.