### PR TITLE
Inverts referrals-only checkbox.

### DIFF
--- a/src/config/eleventy-base-config.js
+++ b/src/config/eleventy-base-config.js
@@ -260,7 +260,7 @@ module.exports = function(eleventyConfig) {
       'income',
       'populationsServed',
       'wheelchairAccessibleOnly',
-      'includeReferrals',
+      'excludeReferrals',
     ];
     let count = 0;
     for (const key in query) {
@@ -770,7 +770,7 @@ module.exports = function(eleventyConfig) {
     // will stay in housingListCopy, but the 'units' array within will be empty.
     // These apartments will be filtered out just prior to returning the
     // final filtered array.
-    if (!query.includeReferrals) {
+    if (query.excludeReferrals) {
       housingListCopy = housingListCopy.filter((a) => !a.disallowsPublicApps);
     }
 

--- a/src/site/serverless/affordable-housing.liquid
+++ b/src/site/serverless/affordable-housing.liquid
@@ -194,9 +194,9 @@ Narrow your search with the filter options below or <a href="#results">scroll</a
         {% if query.wheelchairAccessibleOnly == "on" %}checked{% endif %}>
       <label for="wheelchair-accessible-only">Only show wheelchair-accessible properties</label>
       <br/>
-      <input type="checkbox" id="include-referrals" name="includeReferrals"
-        {% if query.includeReferrals == "on" %}checked{% endif %}>
-      <label for="include-referrals">Include properties requiring an agency referral</label>
+      <input type="checkbox" id="exclude-referrals" name="excludeReferrals"
+        {% if query.excludeReferrals == "on" %}checked{% endif %}>
+      <label for="exclude-referrals">Hide properties requiring an agency referral</label>
       <p data-toggletip data-toggletip-class="icon_query">  
         Some properties only accept applications by referral through a housing agency and do not allow the general public to apply.
       </p>


### PR DESCRIPTION
Since queries are stored in the URL parameters, we need to be careful about backwards-compatibility for anyone who has already saved a URL for a housing search.

This change renames the `includeReferrals` URL param to `excludeReferrals`.  That results in the following behavior for the two possible types of legacy URLs:

- A URL with `includeReferrals=on` in the URL query string will show all properties, including referral-only.  This is because the `includeReferrals` key is no longer valid and therefore ignored.  The new default behavior is to show referrals, so they are shown.  The end result is no change from prior behavior.
- A URL missing `includeReferrals=on` in the query string will _also_ show all properties, including referral-only.  This is different from current behavior, but opting to include _more_ results for a person's saved URL should not be a problem.  We do want to move to default-show of referral-only properties so this supports that.

Fixes #514 