### PR TITLE
Removes old Call for Status compatibility code.

### DIFF
--- a/src/site/_data/housing.js
+++ b/src/site/_data/housing.js
@@ -120,7 +120,7 @@ const fetchUnitRecords = async () => {
         units.push({
           parent_id: record.get('_DISPLAY_ID')?.[0],
           type: record.get('TYPE'),
-          openStatus: record.get('STATUS') === 'Call for Status' ? 'Call for Availability' : record.get('STATUS'),
+          openStatus: record.get('STATUS'),
           occupancyLimit: {
             min: record.get('MIN_OCCUPANCY'),
             max: record.get('MAX_OCCUPANCY'),


### PR DESCRIPTION
Airtable has been updated to replace **Call for Status** with **Call for Availability**

**Call for Status** is now nonexistent in all locations

fixes #612 