### PR TITLE
Groups unit listings by occupancy limits.

### DIFF
--- a/src/config/eleventy-base-config.js
+++ b/src/config/eleventy-base-config.js
@@ -101,6 +101,45 @@ module.exports = function(eleventyConfig) {
     return filtered;
   });
 
+  // Groups items in a collection by one or more keys.
+  // The result is a list of key/value pairs where all items having the same
+  // value for 'keys' in the original 'collection' are grouped.  Specify
+  // multiple grouping keys with a comma-separated list. The result
+  // is a list of group objects having the following properties:
+  //   key: The values of 'keys' in 'collection' that form this group
+  //   values: The items in 'collection' that form this group
+  //   key0..N: The values of keys used to create the group, one for each key
+  //
+  // Example:
+  // const myList = [
+  //   {'type': '1br', 'status': 'open', 'rent': 100},
+  //   {'type': '1br', 'status': 'closed', 'rent': 300},
+  //   {'type': '1br', 'status': 'open', 'rent': 500},
+  //   {'type': '2br', 'status': 'closed', 'rent': 300},
+  // ];
+  // groupBy(myList, 'type,status');
+  //   [
+  //     {
+  //       'key':'1br__open',
+  //       'values':
+  //         [{'type': '1br', 'status': 'open', 'rent': 100},
+  //          {'type': '1br', 'status': 'open', 'rent': 500}],
+  //       'key0': '1br',
+  //       'key1': 'open',
+  //     },
+  //     {
+  //       'key': '1br__closed',
+  //       'values':
+  //         [{'type': '1br', 'status': 'closed', 'rent': 300}]},
+  //       'key0': '1br',
+  //       'key1': 'closed',
+  //     {
+  //       'key': '2br__closed',
+  //       'values':
+  //         [{'type': '2br', 'status': 'closed', 'rent': 100}]},
+  //       'key0': '2br',
+  //       'key1': 'closed',
+  //   ]
   eleventyConfig.addFilter('groupBy', function(collection, keys) {
     const SEPARATOR = '__';
     const groupMap = {};

--- a/src/site/_data/housing.js
+++ b/src/site/_data/housing.js
@@ -121,6 +121,11 @@ const fetchUnitRecords = async () => {
           parent_id: record.get('_DISPLAY_ID')?.[0],
           type: record.get('TYPE'),
           openStatus: record.get('STATUS') === 'Call for Status' ? 'Call for Availability' : record.get('STATUS'),
+          // Combine min and max occupancy into a single string for easier
+          // grouping and sorting later.  This is a convenience only; the
+          // occupancyLimit property below should be used to render apartment
+          // occupancy limits.
+          occupancyGroup: `${record.get('MIN_OCCUPANCY')},${record.get('MAX_OCCUPANCY')}`,
           occupancyLimit: {
             min: record.get('MIN_OCCUPANCY'),
             max: record.get('MAX_OCCUPANCY'),

--- a/src/site/static/apartment-details.liquid
+++ b/src/site/static/apartment-details.liquid
@@ -72,8 +72,14 @@ eleventyComputed:
 
 <div class="rent_tables">
   {% assign defaultNoDataStr = "Call for info" %}
-  {% assign groupByKeys = "type,openStatus" | split: "," %}
-  {% assign sortKeys = "key0,key1" | split: "," %}
+  {% comment %}
+  Min & max occupancy are nested deep within the unit object, so we group by the
+  dedicated top-level 'occupancyGroup' property which just lists the min and
+  max as 'min,max'. This is to avoid supporting nested grouping keys in the
+  groupBy function.
+  {% endcomment %}
+  {% assign groupByKeys = "type,openStatus,occupancyGroup" | split: "," %}
+  {% assign sortKeys = "key0,key1,key2" | split: "," %}
   {% assign unitsByType = apartment.units | groupBy: groupByKeys | rankSort: sortKeys %}
   {% comment %}
   Only show the income bracket column in the rent table if there is more than


### PR DESCRIPTION
With this change, units having the same type and availability are rendered separately if their occupancy limits are different.

## Old behavior 
note the occupancy of 1-2 only applies to the 30% AMI unit.  The 50% and 60% are listed in the database as 1-3 people):
<img width="901" alt="Screenshot 2024-07-02 at 2 20 45 PM" src="https://github.com/theunitedeffort/theunitedeffort.org/assets/4656936/9953d411-1ef0-4e86-a9d2-2e6889eca609">


## New behavior:
<img width="892" alt="Screenshot 2024-07-02 at 2 19 52 PM" src="https://github.com/theunitedeffort/theunitedeffort.org/assets/4656936/1a98d94e-6357-4151-ae4b-21ade27d487d">

I was not able to find any regressions in rendering other units though our test coverage of this type of thing could be better... Like, namely, exist in the first place.
