### PR TITLE
Combines duplicated HUD constants.

### DIFF
--- a/src/site/_includes/js/eligibility.js
+++ b/src/site/_includes/js/eligibility.js
@@ -1574,7 +1574,7 @@ function complexImmigration(input,
 
 // Computes the incremental change in HUD income limit for large family sizes.
 // 'numExtraPeople' is the number of people beyond the max family size given
-// by the array of income limits given my 'limits'.  For example, if 'limits'
+// by the array of income limits given by 'limits'.  For example, if 'limits'
 // defines income limits for household sizes up to 8 people and 'numExtraPeople'
 // is 2, then this function would give the incremental increase from the
 // 8 person limit to the 10 person limit.
@@ -1586,7 +1586,7 @@ const hudLargeFamilyCalc = function(limits, numExtraPeople) {
   const incomeLimit = baseLimit * adjustment;
   const rounded = (cnst.common.hud.INCOME_ROUND_UP_TO_NEAREST * Math.ceil(
     Math.trunc(incomeLimit) / cnst.common.hud.INCOME_ROUND_UP_TO_NEAREST));
-  // Return incremental change ("extra") from the max listed income value.
+  // Return incremental change from the max listed income value.
   return rounded - limits[limits.length - 1];
 };
 

--- a/src/site/_includes/js/test/eligibility-programs.test.js
+++ b/src/site/_includes/js/test/eligibility-programs.test.js
@@ -2190,5 +2190,28 @@ describe('Program eligibility', () => {
       input.income.valid = true;
       check(elig.homelessPreventionSystemResult, input).isEligibleIf('unhousedRisk').is(true);
     });
+
+    // This program has a particularly complex income limit calculation for
+    // household sizes above the maximum size listed in the limit table.  This
+    // Test ensures the calculation was done correctly by checking against the
+    // values given by the HUD income limit calculator.
+    test('Extended income limit is computed correctly', () => {
+      // https://www.huduser.gov/portal/datasets/il/il2024/2024ILCalc3080.odn?inputname=Santa+Clara+County&area_id=METRO41940M41940&fips=0608599999&type=county&year=2024&yy=24&stname=California&stusps=CA&statefp=06&ACS_Survey=%24ACS_Survey%24&State_Count=%24State_Count%24&areaname=%24passname%24&incpath=%24incpath%24&level=80
+      const expectedAnnualLimitNinePpl = 204550;
+      const expectedAnnualLimitTwentyFivePpl = 391550;
+
+      input.income.valid = true;
+      input.unhousedRisk = true;
+
+      input.householdSize = 9;
+      let maxIncome = expectedAnnualLimitNinePpl / 12;
+      check(elig.homelessPreventionSystemResult, input)
+        .isEligibleIf('income.wages').isAtMost(maxIncome);
+
+      input.householdSize = 25;
+      maxIncome = expectedAnnualLimitTwentyFivePpl / 12;
+      check(elig.homelessPreventionSystemResult, input)
+        .isEligibleIf('income.wages').isAtMost(maxIncome);
+    });
   });
 });


### PR DESCRIPTION
This change mostly just moves existing constants and code though there was a small code change as well.

Duplicated constants were moved into `cnst.common.hud` and the duplicated math in the two `extraCalc` functions has been renamed to `hudLargeFamilyCalc` and moved to a shared location.

The constant `FAMILY_SIZE_ADJ_8` has been removed because its use assumed an income limit array length of 8.  Instead, the actual income limit array length is used to calculate the adjustment factor.  At the moment this makes no difference because the two programs that use this computation (Homelessness Prevention System and Housing Choice Voucher) have income limit arrays of length 8.  But this way things are a bit more generalized.