### PR TITLE
Added HTTP error message on 404 page

### DIFF
--- a/src/site/static/404.liquid
+++ b/src/site/static/404.liquid
@@ -9,6 +9,9 @@ permalink: /404.html
 
 {% assign emailAddress = "help@theunitedeffort.org" %}
 {% assign emailSubject = "Help finding a UEO webpage" %}
+<p style="opacity: 60%;">
+  HTTP Error 404 - Not Found
+</p>
 <p>
   The page you are looking for does not exist.  It could be because a link you followed is out of date, or perhaps we have moved our pages around.
 </p>


### PR DESCRIPTION
Displays the 404 error message on the 404 page. Not particularly useful but I think it's a good thing to have.