### PR TITLE
Deactivates the lint linebreak style checking

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,8 @@
         "ignoreUrls": true,
         "ignoreStrings": true
       }
-    ]
+    ],
+    "linebreak-style": 0
   },
   "ignorePatterns": []
 }


### PR DESCRIPTION
On Windows machines, `npm run lint` spits out 13k+ errors because Windows uses CRLF and not LF for line breaks. This can be fixed by simply disabling linebreak style checking, which probably isn't needed anyway.

![image](https://github.com/user-attachments/assets/aa0c9a2a-8855-4a4e-8c57-2d347751a2c8)
