### PR TITLE
Adds note warning of Safari table print bug

### DIFF
--- a/src/site/serverless/affordable-housing-table.liquid
+++ b/src/site/serverless/affordable-housing-table.liquid
@@ -19,6 +19,11 @@ pageHead: '<style type="text/css" media="print">@page {size: landscape;}</style>
   <p>Filters Applied:<br/> {% querySummary query %}</p>
 {% endif %}
 
+{% comment %} TODO: remove this note after fixing #160 {% endcomment %}
+<p class="note noprint">
+  Printing this table on Safari may cause some text and table rows to print incorrectly. If you experience this issue, please try printing using a different browser.
+</p>
+
 <div class="flex align_end">
   <h3>Showing {% if numFiltersApplied == 0 %}all {% endif %} {{numResults}} {{numResults | pluralize: "property", "properties"}}</h3>
 

--- a/src/site/serverless/affordable-housing-tracker.liquid
+++ b/src/site/serverless/affordable-housing-tracker.liquid
@@ -64,6 +64,11 @@ pageHead: '<style type="text/css" media="print">@page {size: landscape;}</style>
   </p>
 {% endif %}
 
+{% comment %} TODO: remove this note after fixing #160 {% endcomment %}
+<p class="note noprint">
+  Printing this table on Safari may cause some text and table rows to print incorrectly. If you experience this issue, please try printing using a different browser.
+</p>
+
 <h3>{{numResults}} {{numResults | pluralize: "property", "properties"}} total</h3>
 <div class="flex">
   <p class="noprint collapse_top">

--- a/src/site/serverless/shelter-resources-table.liquid
+++ b/src/site/serverless/shelter-resources-table.liquid
@@ -19,6 +19,11 @@ pageHead: '<style type="text/css" media="print">@page {size: landscape;}</style>
   <p>Filters Applied:<br/> {% querySummary query %}</p>
 {% endif %}
 
+{% comment %} TODO: remove this note after fixing #160 {% endcomment %}
+<p class="note noprint">
+  Printing this table on Safari may cause some text and table rows to print incorrectly. If you experience this issue, please try printing using a different browser.
+</p>
+
 <div class="flex align_end">
   <h3>Showing {% if numFiltersApplied == 0 %}all {% endif %} {{numResults}} {{numResults | pluralize: "shelter", "shelters"}}</h3>
 


### PR DESCRIPTION
I don't have a Mac so I can't test #160, but until this is fixed I suggest we add a note flag warning users that tables may print incorrectly on Safari.