### PR TITLE
Refactors CMS data to be global.

### DIFF
--- a/src/site/_data/cms.js
+++ b/src/site/_data/cms.js
@@ -165,6 +165,12 @@ const fetchAssets = async () => {
 
 
 module.exports = async function() {
+  // Only housing pages run serverless, so there is no need to fetch
+  // all this content when this data file is executed from a serverless
+  // environment.
+  if (process.env.ELEVENTY_SERVERLESS) {
+    return {};
+  }
   const asset = new eleventyFetch.AssetCache('airtable_pages');
   if (asset.isCacheValid('1h')) {
     console.log('Returning cached pages data.');

--- a/src/site/static/affordable-housing-changes-help.liquid
+++ b/src/site/static/affordable-housing-changes-help.liquid
@@ -18,7 +18,7 @@ pageClass: "smaller"
 </p>
 <figure>
   <p>
-    {% image images.example-hud-ami-table, "png" %}
+    {% image cms.images.example-hud-ami-table, "png" %}
   </p>
   <figcaption>Example maximum income table for "Low" (80% AMI), "Very Low" (50% AMI), and "Extremely Low" (30% AMI) income levels for Santa Clara county. (<a href="https://www.huduser.gov/portal/datasets/il/il2023/2023summary.odn?states=6.0&data=2023&inputname=METRO41940M41940*0608599999%2BSanta+Clara+County&stname=California&statefp=06&year=2023&selection_type=county" target="_blank">source</a>)</figcaption>
 </figure>
@@ -45,7 +45,7 @@ pageClass: "smaller"
 </p>
 <figure>
   <p>
-    {% image images.example-full-bmr-website, "png" %}
+    {% image cms.images.example-full-bmr-website, "png" %}
   </p>
   <figcaption>Example website for a property offering exclusively below market rate apartments.  Info for our database is easier to find here. (<a href="https://altahousing.org/properties/tree-house-apartments/" target="_blank">source</a>)</figcaption>
 </figure>
@@ -54,7 +54,7 @@ pageClass: "smaller"
 </p>
 <figure>
   <p>
-    {% image images.example-market-rate-website, "png" %}
+    {% image cms.images.example-market-rate-website, "png" %}
   </p>
   <figcaption>Example website for a market-rate property with some BMR units within. Info for our database is often not listed here. (<a href="https://www.mvapartments.com/" target="_blank">source</a>)</figcaption>
 </figure>
@@ -78,7 +78,7 @@ pageClass: "smaller"
   </li>
   <figure>
     <p>
-      {% image images.launch-page-half-screen, "png" %}
+      {% image cms.images.launch-page-half-screen, "png" %}
     </p>
     <figcaption>Use the orange ruler at the bottom of the launch page to help you resize the browser window to fill the right half of your screen.</figcaption>
   </figure>
@@ -89,7 +89,7 @@ pageClass: "smaller"
   </li>
   <figure>
     <p>
-      {% image images.launch-page-with-changes-form, "png" %}
+      {% image cms.images.launch-page-with-changes-form, "png" %}
     </p>
     <figcaption>Once your browser window is sized correctly, click the start button to launch the data entry interface on the left.  Enter your name in the top field.</figcaption>
   </figure>
@@ -114,7 +114,7 @@ pageClass: "smaller"
     </p>
     <figure>
       <p>
-        {% image images.rent-and-income-mapping, "png" %}
+        {% image cms.images.rent-and-income-mapping, "png" %}
       </p>
       <figcaption>Find data in the property website on the right and use it to update the database fields on the left. This example shows how the data for a studio being offered at two income levels gets input into the form.</figcaption>
     </figure>
@@ -144,13 +144,13 @@ pageClass: "smaller"
 </p>
 <figure>
   <p>
-    {% image images.charities-housing-waitlist, "png" %}
+    {% image cms.images.charities-housing-waitlist, "png" %}
   </p>
   <figcaption>Example of a website showing open-waitlist properties on a central overview page rather than denoting waitlist status within each individual property details page. (<a href="https://charitieshousing.org/find-a-home/" target="_blank">source</a>)</figcaption>
 </figure>
 <figure>
   <p>
-    {% image images.first-community-waitlist, "png" %}
+    {% image cms.images.first-community-waitlist, "png" %}
   </p>
   <figcaption>Another example of a website showing the waitlist status of all properties on a central overview page rather than denoting waitlist status within each individual property details page. (<a href="https://www.firstcommunityhousing.org/residencies" target="_blank">source</a>)</figcaption>
 </figure>
@@ -161,7 +161,7 @@ pageClass: "smaller"
 </p>
 <figure>
   <p>
-    {% image images.example-move-in-qualification, "png" %}
+    {% image cms.images.example-move-in-qualification, "png" %}
   </p>
   <figcaption>This property does not directly display rent and maximum income values but rather links to a document containing that information.  Be sure to click on links to find detailed information! (<a href="https://www.eahhousing.org/apartments/cochrane-village/" target="_blank">source</a>)</figcaption>
 </figure>
@@ -173,7 +173,7 @@ pageClass: "smaller"
 </p>
 <figure>
   <p>
-    {% image images.general-population-group, "png" %}
+    {% image cms.images.general-population-group, "png" %}
   </p>
   <figcaption>An example of a property website and the corresponding selections for the populations served field.  The property is listed as "family housing" which is equivalent to "general population" (<a href="https://jscosccha.com/property/poco-way-apartments/" target="_blank">source</a>)</figcaption>
 </figure>
@@ -182,13 +182,13 @@ pageClass: "smaller"
 </p>
 <figure>
   <p>
-    {% image images.developmentally-disabled-group, "png" %}
+    {% image cms.images.developmentally-disabled-group, "png" %}
   </p>
   <figcaption>An example of a property website and the corresponding selections for the populations served field.  The property is listed as "special needs" which is equivalent to serving only the "developmentally disabled." Note that "general population" is not selected, because the property only serves the developmentally disabled.(<a href="https://edenhousing.org/properties/edenvale/" target="_blank">source</a>)</figcaption>
 </figure>
 <figure>
   <p>
-    {% image images.two-population-groups, "png" %}
+    {% image cms.images.two-population-groups, "png" %}
   </p>
   <figcaption>An example of a property website and the corresponding selections for the populations served field.  The property notes it is for seniors but also reserves some units for the developmentally disabled, so both are selected in the data entry form. (<a href="https://www.firstcommunityhousing.org/japan-town-senior-apartments" target="_blank">source</a>)</figcaption>
 </figure>

--- a/src/site/static/pages.liquid
+++ b/src/site/static/pages.liquid
@@ -36,13 +36,13 @@ eleventyComputed:
   <div class="{{section.type | downcase }}">
     {% if section.type == "Pancake" %}
       <div class="container">
-      {{ section.content | markdownify | unplaceholder: images}}
+      {{ section.content | markdownify | unplaceholder: cms.images }}
       </div>
     {% elsif section.type == "Render-partial" %}
       {% assign partialName = section.content | strip %}
-      {% render partialName, data: partialsData %}
+      {% render partialName, data: cms.partialsData %}
     {% else %}
-      {{ section.content | markdownify | unplaceholder: images}}
+      {{ section.content | markdownify | unplaceholder: cms.images }}
     {% endif %}
 
   </div>

--- a/src/site/static/pages.liquid
+++ b/src/site/static/pages.liquid
@@ -1,7 +1,7 @@
 ---
 layout: "layouts/base.liquid"
 pagination:
-  data: pages
+  data: cms.pages
   size: 1
   alias: thisPage
 permalink: "{{ thisPage.url }}/index.html"

--- a/src/site/static/stories.liquid
+++ b/src/site/static/stories.liquid
@@ -1,7 +1,7 @@
 ---
 layout: "layouts/base.liquid"
 pagination:
-  data: partialsData.stories
+  data: cms.partialsData.stories
   size: 1
   alias: story
 pageClass: "page-about"


### PR DESCRIPTION
Housing searches should be as fast as possible. They run in a serverless environment, which by default executes all global data files when rendering.  So, only the housing-related data files were global.  With this change, the CMS data file is moved back to the global dir, but modified so that nothing happens if executed in a serverless environment.

With the CMS data file as a directory-level data file, it was getting called many times in succession: once for each template in that directory.  All those API calls are definitely not necessary
