### PR TITLE
Updates CARE/FERA limits, removes household size limit for FERA.

### DIFF
--- a/src/site/_includes/js/eligibility.js
+++ b/src/site/_includes/js/eligibility.js
@@ -72,18 +72,18 @@ const cnst = {
   },
   care: {
     // https://www.cpuc.ca.gov/industries-and-topics/electrical-energy/electric-costs/care-fera-program
-    // Effective through 5/31/2025
+    // Effective through 5/31/2026
     ANNUAL_INCOME_LIMITS: [ // USD per year
-      40880,
-      40880,
-      51640,
-      62400,
-      73160,
-      83920,
-      94680,
-      105440,
+      42300,
+      42300,
+      53300,
+      64300,
+      75300,
+      86300,
+      97300,
+      108300,
     ],
-    ANNUAL_INCOME_LIMIT_ADDL_PERSON: 10760, // USD per year per person
+    ANNUAL_INCOME_LIMIT_ADDL_PERSON: 11000, // USD per year per person
   },
   clipper: {
     // https://www.clipperstartcard.com/s/
@@ -103,19 +103,18 @@ const cnst = {
   },
   fera: {
     // https://www.cpuc.ca.gov/industries-and-topics/electrical-energy/electric-costs/care-fera-program
-    // Effective through 5/31/2025
+    // Effective through 5/31/2026
     ANNUAL_INCOME_LIMITS: [ // USD per year
-      64550, // Min household size 3.
-      64550, // Min household size 3.
-      64550,
-      78000,
-      91450,
-      104900,
-      118350,
-      131800,
+      52875,
+      52875,
+      66625,
+      80375,
+      94125,
+      107875,
+      121625,
+      135375,
     ],
-    ANNUAL_INCOME_LIMIT_ADDL_PERSON: 13450, // USD per year per person
-    MIN_HOUSEHOLD_SIZE: 3, // People
+    ANNUAL_INCOME_LIMIT_ADDL_PERSON: 13750, // USD per year per person
   },
   ga: {
     // https://stgenssa.sccgov.org/debs/program_handbooks/charts/assets/4GA/NeedStnds.htm
@@ -2053,9 +2052,6 @@ function feraResult(input) {
   const incomeLimitFera = grossLimit.getLimit(input.householdSize);
   const underFeraIncomeLimit = le(grossIncome(input), incomeLimitFera);
 
-  const meetsHouseholdSizeReq = ge(input.householdSize,
-    cnst.fera.MIN_HOUSEHOLD_SIZE);
-
   const program = new Program();
   program.addCondition(
     new EligCondition('Be housed', isHoused));
@@ -2070,10 +2066,6 @@ function feraResult(input) {
     new EligCondition(`Have a gross income under the FERA program limit of ` +
       `${usdLimit(incomeLimitFera)} per month`,
     underFeraIncomeLimit));
-  program.addCondition(
-    new EligCondition(`Have a household of at least ` +
-      `${cnst.fera.MIN_HOUSEHOLD_SIZE} people`,
-    meetsHouseholdSizeReq));
 
   if (input.existingFeraMe || input.existingFeraHousehold) {
     program.markEnrolled();

--- a/src/site/_includes/js/test/eligibility-programs.test.js
+++ b/src/site/_includes/js/test/eligibility-programs.test.js
@@ -1030,9 +1030,8 @@ describe('Program eligibility', () => {
   describe('FERA Program', () => {
     let expectedLowIncomeLimit;
     beforeEach(() => {
-      const incomeIdx = elig.cnst.fera.MIN_HOUSEHOLD_SIZE - 1;
       expectedLowIncomeLimit = (
-        elig.cnst.care.ANNUAL_INCOME_LIMITS[incomeIdx] / 12);
+        elig.cnst.care.ANNUAL_INCOME_LIMITS[input.householdSize - 1] / 12);
     });
 
     test('Not eligible with default input', () => {
@@ -1045,20 +1044,7 @@ describe('Program eligibility', () => {
         'existingFeraHousehold').is(true);
     });
 
-    test('Requires minimum household size', () => {
-      input.income.valid = true;
-      input.income.wages = [[expectedLowIncomeLimit + 1]];
-      input.housingSituation = 'housed';
-      input.paysUtilities = true;
-      // Start with a household that's too small.
-      input.householdSize = elig.cnst.fera.MIN_HOUSEHOLD_SIZE - 1;
-      // Then ensure a result of eligible when the household size is increased.
-      check(elig.feraResult, input)
-        .isEligibleIf('householdSize').is(elig.cnst.fera.MIN_HOUSEHOLD_SIZE);
-    });
-
     test('Requires utility bill payment', () => {
-      input.householdSize = elig.cnst.fera.MIN_HOUSEHOLD_SIZE;
       input.income.valid = true;
       input.income.wages = [[expectedLowIncomeLimit + 1]];
       input.housingSituation = 'housed';
@@ -1066,7 +1052,6 @@ describe('Program eligibility', () => {
     });
 
     test('Requires being housed', () => {
-      input.householdSize = elig.cnst.fera.MIN_HOUSEHOLD_SIZE;
       input.income.valid = true;
       input.income.wages = [[expectedLowIncomeLimit + 1]];
       input.paysUtilities = true;
@@ -1078,7 +1063,6 @@ describe('Program eligibility', () => {
     });
 
     test('Requires income above CARE limit', () => {
-      input.householdSize = elig.cnst.fera.MIN_HOUSEHOLD_SIZE;
       input.income.valid = true;
       input.housingSituation = 'housed';
       input.paysUtilities = true;
@@ -1088,7 +1072,6 @@ describe('Program eligibility', () => {
     });
 
     test('Requires income at or below FERA limit', () => {
-      input.householdSize = elig.cnst.fera.MIN_HOUSEHOLD_SIZE;
       const testIncome = (
         elig.cnst.fera.ANNUAL_INCOME_LIMITS[input.householdSize - 1] / 12);
       input.income.valid = true;


### PR DESCRIPTION
Minimum household size of 3 seems to have been removed as a requirement per https://www.cpuc.ca.gov/industries-and-topics/electrical-energy/electric-costs/care-fera-program and https://www.pge.com/en/account/billing-and-assistance/financial-assistance/family-electric-rate-assistance-program-fera.html